### PR TITLE
add Diffusers Format Support for DeepGen-1.0

### DIFF
--- a/INFERENCE.md
+++ b/INFERENCE.md
@@ -6,7 +6,7 @@ huggingface-cli download deepgenteam/DeepGen-1.0  --local-dir checkpoints --repo
 
 # Merge zip
 cat DeepGen_CKPT.zip.part-* > DeepGen_CKPT.zip
-# Unzip DeepGen checkpoints 
+# Unzip DeepGen checkpoints
 unzip DeepGen_CKPT.zip
 ```
 
@@ -45,7 +45,7 @@ python scripts/image2image.py
              --seed 42
 ```
 
-# Diffusers Format (Recommended)
+# Diffusers Format
 
 We also provide a diffusers-compatible format at 🤗[deepgenteam/DeepGen-1.0-diffusers](https://huggingface.co/deepgenteam/DeepGen-1.0-diffusers). This is a self-contained pipeline that **does not require cloning the DeepGen repository**.
 
@@ -104,17 +104,3 @@ result = pipe(
 result.images[0].save("edited.png")
 ```
 
-### Converting model.pt to Diffusers Format
-
-If you want to convert a checkpoint yourself:
-
-```bash
-export PYTHONPATH=.
-python scripts/convert_to_diffusers.py \
-    --checkpoint /path/to/model.pt \
-    --output_dir /path/to/output \
-    --vlm_path /path/to/Qwen2.5-VL-3B-Instruct \
-    --dit_path /path/to/UniPic2-SD3.5M-Kontext-2B \
-    --push_to_hub deepgenteam/DeepGen-1.0-diffusers \
-    --hf_token YOUR_TOKEN
-```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ We propose DeepGen 1.0, a lightweight unified multimodal model with only 5B para
 
 ## 🧠 Method
 Our core observation is that a lightweight model, when empowered by synergistic architecture design and data-centric training strategies, can achieve comprehensive capabilities competitive with or even surpassing much larger counterparts.
-To overcome the limitations of lightweight models in semantic understanding and fine-grained control, we introduce **Stacked Channel Bridging (SCB)**, a deep alignment framework that extracts hierarchical features from multiple VLM layers and fuses them with learnable "think tokens" to provide the generative backbone with structured, reasoning-rich guidance. 
+To overcome the limitations of lightweight models in semantic understanding and fine-grained control, we introduce **Stacked Channel Bridging (SCB)**, a deep alignment framework that extracts hierarchical features from multiple VLM layers and fuses them with learnable "think tokens" to provide the generative backbone with structured, reasoning-rich guidance.
 We further design a data-centric training strategy spanning three progressive stages: (1) **Alignment Pre-training** on large-scale image-text pairs and editing triplets to synchronize VLM and DiT representations, (2) **Joint Supervised Fine-tuning** on a high-quality mixture of generation, editing, and reasoning tasks to foster omni-capabilities, and (3) **Reinforcement Learning with MR-GRPO**, which leverages a mixture of reward functions and supervision signals, resulting in substantial gains in generation quality and alignment with human preferences, while maintaining stable training progress and avoiding visual artifacts.
 
 <p align="center"><img src="figure/arch.png" width="80%"></p>
@@ -74,7 +74,44 @@ pip install -U opencv-python-headless
 Please See [DATA](DATA.md) for more details. We provide a detailed description of the data download and usage procedures for both the Pre-traning stage and the Supervised Fine-Tuning stage.
 
 ### Inference
-Please refer to [INFERENCE](INFERENCE.md)
+
+#### Diffusers
+
+```bash
+pip install torch diffusers transformers safetensors einops accelerate
+pip install flash-attn --no-build-isolation  # optional but recommended
+```
+
+**Text-to-Image:**
+```python
+import torch
+from diffusers import DiffusionPipeline
+
+pipe = DiffusionPipeline.from_pretrained(
+    "deepgenteam/DeepGen-1.0-diffusers",
+    torch_dtype=torch.bfloat16,
+    trust_remote_code=True,
+)
+pipe.enable_model_cpu_offload() # Optional
+
+result = pipe("a racoon holding a shiny red apple over its head",
+              height=512, width=512, num_inference_steps=50, guidance_scale=4.0, seed=42)
+result.images[0].save("output.png")
+```
+
+**Image Editing:**
+```python
+from PIL import Image
+
+result = pipe("Place this guitar on a sandy beach with sunset in the background.",
+              image=Image.open("guitar.png"), height=512, width=512,
+              num_inference_steps=50, guidance_scale=4.0, seed=42)
+result.images[0].save("edited.png")
+```
+
+#### Native Pipeline
+
+Please refer to [INFERENCE](INFERENCE.md) for the native pipeline usage.
 
 ### Train
 We provide the scripts for Interleaved Reasoning Tuning.
@@ -82,11 +119,11 @@ We provide the scripts for Interleaved Reasoning Tuning.
 bash scripts/sft.sh
 ```
 
-You can replace the variables in the script with your own before running. 
-See [TRAIN](TRAIN.md) for more details. We provide a detailed description of the data download and usage procedures for both the pretraining stage and the SFT stage. 
+You can replace the variables in the script with your own before running.
+See [TRAIN](TRAIN.md) for more details. We provide a detailed description of the data download and usage procedures for both the pretraining stage and the SFT stage.
 
 ### Eval
-We provide the scripts for evaluating T2I and Editing benchmarks, support World Knowledge-Enhanced Textual Reasoning and Fine-grained Editing-like Visual Refinement. 
+We provide the scripts for evaluating T2I and Editing benchmarks, support World Knowledge-Enhanced Textual Reasoning and Fine-grained Editing-like Visual Refinement.
 Please See [EVAL](EVAL.md) for more details.
 
 ## 📊 Benchmarks


### PR DESCRIPTION
## Overview

This PR adds diffusers format support for DeepGen-1.0, allowing users to load and use the model without cloning the DeepGen repository.

**Changes:**
- Update `INFERENCE.md`: Add diffusers format usage instructions

**HuggingFace Model:**
- Converted model uploaded to [deepgenteam/DeepGen-1.0-diffusers](https://huggingface.co/deepgenteam/DeepGen-1.0-diffusers)

## Converted Model Structure

```
DeepGen-1.0-diffusers/
├── transformer/          # SD3 DiT (4.6 GB safetensors)
├── vae/                  # AutoencoderKL (160 MB safetensors)
├── connector/            # SCB Connector + Projectors + MetaQueries (1.6 GB safetensors)
├── scheduler/            # FlowMatchEulerDiscreteScheduler config
├── tokenizer/            # Qwen2.5-VL tokenizer
├── prompt_template.json  # Prompt formatting template
├── model_index.json      # Model metadata
└── deepgen_pipeline.py   # Self-contained pipeline script
```

The VLM (Qwen2.5-VL-3B-Instruct) is loaded automatically from [Qwen/Qwen2.5-VL-3B-Instruct](https://huggingface.co/Qwen/Qwen2.5-VL-3B-Instruct). You can also specify a local path via the `vlm_model_path` parameter.

## Usage Examples

### Installation

```bash
pip install torch diffusers transformers safetensors einops accelerate huggingface_hub
pip install flash-attn --no-build-isolation  # recommended
```

### Text-to-Image Generation

```python
import torch
from diffusers import DiffusionPipeline

pipe = DiffusionPipeline.from_pretrained(
    "deepgenteam/DeepGen-1.0-diffusers",
    torch_dtype=torch.bfloat16,
    trust_remote_code=True,
)
pipe.to("cuda")
pipe.enable_model_cpu_offload()  # recommended for GPUs with < 24GB VRAM

result = pipe(
    prompt="a racoon holding a shiny red apple over its head",
    height=512, width=512,
    num_inference_steps=50,
    guidance_scale=4.0,
    seed=42,
)
result.images[0].save("output.png")
```

### Image Editing

```python
from PIL import Image

source_image = Image.open("guitar.png").convert("RGB")
result = pipe(
    prompt="Take a photo of this guitar placed on a sandy beach with the sunset in the background.",
    image=source_image,
    height=512, width=512,
    num_inference_steps=50,
    guidance_scale=4.0,
    seed=42,
)
result.images[0].save("edited.png")
```

## Test Results

All tests use `DiffusionPipeline.from_pretrained(..., trust_remote_code=True)` with `enable_model_cpu_offload()`. Both `flash_attention_2` and `sdpa` attention implementations produce correct, visually identical results.

**Case A — Text-to-Image: "a racoon holding a shiny red apple over its head"**

| flash_attention_2 | sdpa |
|:--:|:--:|
| <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/fc31fae0-bcab-4482-9fb9-6f708c69116c" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/dc25f85e-c657-4092-96e8-d244c913ba97" /> |

**Case B — Image Edit: guitar → sandy beach with sunset**

| Input | flash_attention_2 | sdpa |
|:--:|:--:|:--:|
| <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/09db49e1-a5d7-4e7a-84e0-7bc3c76cbe4f" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/fe4df7fc-0a42-44b8-8b5e-831197bc6110" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/8b17d158-a37a-4a1a-8b27-693820af6d58" /> |

**Case C — Image Edit: antique car + add a small brown dog**

| Input | flash_attention_2 | sdpa |
|:--:|:--:|:--:|
| <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/305ef661-497c-422e-ab14-53189db33c3c" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/f6bf6c08-0281-4fc9-b175-4a3598d41d07" /> | <img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/c49a48ff-6ff2-438b-b627-9ff0b86e6a32" /> |

## Memory Requirements

| Mode | VRAM |
|------|------|
| Full GPU | ~20 GB |
| CPU Offload (`pipe.enable_model_cpu_offload()`) | ~14 GB |

## Technical Notes

1. **Diffusers Integration**: `DeepGenPipeline` inherits from `DiffusionPipeline`, so standard diffusers components (transformer, vae, scheduler) are loaded automatically; non-standard components (VLM, connector, tokenizer) are loaded on first call via lazy initialization
2. **Attention Compatibility**: VLM supports both `flash_attention_2` (recommended) and `sdpa` (fallback); connector always uses `sdpa`; automatic fallback if flash-attn is not installed
3. **CPU Offload**: Implements 3-stage sequential offload (VLM+Connector → DiT → VAE), enabling inference on GPUs with as little as 14GB VRAM
4. **Conversion Script**: Uses a symlink trick to avoid modifying repository config files; builds the full model via mmengine then saves each component separately

## Scripts

<details>
<summary>scripts/convert_to_diffusers.py — model.pt → diffusers format (click to expand)</summary>

```python
"""
Convert DeepGen-1.0 model.pt to diffusers-compatible format.

Usage:
    export PYTHONPATH=.
    python scripts/convert_to_diffusers.py \
        --checkpoint /path/to/model.pt \
        --output_dir /path/to/DeepGen-1.0-diffusers \
        --vlm_path /data/huggingface/Qwen2.5-VL-3B-Instruct \
        --dit_path /data/huggingface/UniPic2-SD3.5M-Kontext-2B \
        [--push_to_hub deepgenteam/DeepGen-1.0-diffusers] \
        [--hf_token YOUR_TOKEN]
"""

import os
import sys
import json
import math
import argparse
import torch
import torch.nn as nn
from safetensors.torch import save_file


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("--checkpoint", type=str, required=True)
    parser.add_argument("--output_dir", type=str, required=True)
    parser.add_argument("--vlm_path", type=str, required=True,
                        help="Local path to Qwen2.5-VL-3B-Instruct")
    parser.add_argument("--dit_path", type=str, required=True,
                        help="Local path to UniPic2-SD3.5M-Kontext-2B")
    parser.add_argument("--push_to_hub", type=str, default=None)
    parser.add_argument("--hf_token", type=str, default=None)
    args = parser.parse_args()

    os.makedirs(args.output_dir, exist_ok=True)

    # Temporarily patch config paths via symlinks
    model_zoo_dir = os.path.join(os.getcwd(), "model_zoo")
    created_symlinks = []
    try:
        os.makedirs(model_zoo_dir, exist_ok=True)
        vlm_link = os.path.join(model_zoo_dir, "Qwen2.5-VL-3B-Instruct")
        dit_link = os.path.join(model_zoo_dir, "UniPic2-SD3.5M-Kontext-2B")
        if not os.path.exists(vlm_link):
            os.symlink(args.vlm_path, vlm_link)
            created_symlinks.append(vlm_link)
        if not os.path.exists(dit_link):
            os.symlink(args.dit_path, dit_link)
            created_symlinks.append(dit_link)

        from mmengine.config import Config
        from xtuner.registry import BUILDER
        from xtuner.model.utils import guess_load_checkpoint

        # 1. Build model from config (override flash_attention_2 -> sdpa if flash_attn unavailable)
        print("Building model from config...")
        config = Config.fromfile("configs/models/deepgen_scb.py")
        try:
            import flash_attn
        except ImportError:
            print("flash_attn not available, falling back to sdpa...")
            config.model['connector']['_attn_implementation'] = 'sdpa'
            config.model['lmm']['attn_implementation'] = 'sdpa'
        model = BUILDER.build(config.model)

        # 2. Load checkpoint
        print(f"Loading checkpoint: {args.checkpoint}")
        if args.checkpoint.endswith('.pt'):
            state_dict = torch.load(args.checkpoint, map_location='cpu')
        else:
            state_dict = guess_load_checkpoint(args.checkpoint)
        missing, unexpected = model.load_state_dict(state_dict, strict=False)
        print(f"Missing keys (expected - vae/lmm): {len(missing)}")
        if unexpected:
            print(f"Unexpected keys: {unexpected}")

        # 3. Save transformer
        print("Saving transformer...")
        transformer_dir = os.path.join(args.output_dir, "transformer")
        model.transformer.save_pretrained(transformer_dir, safe_serialization=True)

        # 4. Save VAE
        print("Saving VAE...")
        vae_dir = os.path.join(args.output_dir, "vae")
        model.vae.save_pretrained(vae_dir, safe_serialization=True)

        # 5. Save scheduler
        print("Saving scheduler...")
        scheduler_dir = os.path.join(args.output_dir, "scheduler")
        model.test_scheduler.save_pretrained(scheduler_dir)

        # 6. Save connector + projectors + meta_queries
        print("Saving connector...")
        connector_dir = os.path.join(args.output_dir, "connector")
        os.makedirs(connector_dir, exist_ok=True)

        connector_state = {}
        for k, v in model.connector.state_dict().items():
            connector_state[f"connector.{k}"] = v
        for k, v in model.projector_1.state_dict().items():
            connector_state[f"projector_1.{k}"] = v
        for k, v in model.projector_2.state_dict().items():
            connector_state[f"projector_2.{k}"] = v
        for k, v in model.projector_3.state_dict().items():
            connector_state[f"projector_3.{k}"] = v
        connector_state["meta_queries"] = model.meta_queries.data

        save_file(connector_state, os.path.join(connector_dir, "model.safetensors"))

        connector_config = {
            "connector": {
                "hidden_size": model.connector.config.hidden_size,
                "intermediate_size": model.connector.config.intermediate_size,
                "num_hidden_layers": model.connector.config.num_hidden_layers,
                "num_attention_heads": model.connector.config.num_attention_heads,
                "hidden_act": model.connector.config.hidden_act,
                "layer_norm_eps": model.connector.config.layer_norm_eps,
                "attention_dropout": model.connector.config.attention_dropout,
            },
            "num_queries": model.num_queries,
            "projector_1_in": model.projector_1.in_features,
            "projector_1_out": model.projector_1.out_features,
            "projector_2_in": model.projector_2.in_features,
            "projector_2_out": model.projector_2.out_features,
            "projector_3_in": model.projector_3.in_features,
            "projector_3_out": model.projector_3.out_features,
            "llm_hidden_size": model.llm.config.hidden_size,
            "max_length": model.max_length,
        }
        with open(os.path.join(connector_dir, "config.json"), "w") as f:
            json.dump(connector_config, f, indent=2)

        # 7. Save prompt template
        print("Saving prompt template...")
        prompt_template = config.model['prompt_template']
        with open(os.path.join(args.output_dir, "prompt_template.json"), "w") as f:
            json.dump(prompt_template, f, indent=2)

        # 8. Save model_index.json
        model_index = {
            "_class_name": ["deepgen_pipeline", "DeepGenPipeline"],
            "_diffusers_version": "0.35.2",
            "transformer": ["diffusers", "SD3Transformer2DModel"],
            "vae": ["diffusers", "AutoencoderKL"],
            "scheduler": ["diffusers", "FlowMatchEulerDiscreteScheduler"],
            "vlm": "Qwen/Qwen2.5-VL-3B-Instruct",
        }
        with open(os.path.join(args.output_dir, "model_index.json"), "w") as f:
            json.dump(model_index, f, indent=2)

        # 9. Save tokenizer
        print("Saving tokenizer...")
        tokenizer_dir = os.path.join(args.output_dir, "tokenizer")
        model.tokenizer.save_pretrained(tokenizer_dir)

        print(f"\nConversion complete! Saved to: {args.output_dir}")
        print("Directory structure:")
        for root, dirs, files in os.walk(args.output_dir):
            level = root.replace(args.output_dir, '').count(os.sep)
            indent = ' ' * 2 * level
            print(f'{indent}{os.path.basename(root)}/')
            subindent = ' ' * 2 * (level + 1)
            for file in files:
                fsize = os.path.getsize(os.path.join(root, file))
                if fsize > 1024 * 1024:
                    print(f'{subindent}{file} ({fsize / 1024 / 1024:.1f} MB)')
                else:
                    print(f'{subindent}{file} ({fsize / 1024:.1f} KB)')

        # 10. Push to hub
        if args.push_to_hub:
            print(f"\nPushing to HuggingFace Hub: {args.push_to_hub}")
            from huggingface_hub import HfApi, create_repo
            api = HfApi(token=args.hf_token)
            try:
                create_repo(args.push_to_hub, repo_type="model", exist_ok=True, token=args.hf_token)
            except Exception as e:
                print(f"Note: {e}")
            api.upload_folder(
                folder_path=args.output_dir,
                repo_id=args.push_to_hub,
                repo_type="model",
            )
            print("Push complete!")

    finally:
        # Clean up symlinks
        for link in created_symlinks:
            if os.path.islink(link):
                os.unlink(link)
                print(f"Cleaned up symlink: {link}")
        if os.path.isdir(model_zoo_dir) and not os.listdir(model_zoo_dir):
            os.rmdir(model_zoo_dir)
            print("Cleaned up model_zoo/")


if __name__ == "__main__":
    main()
```

</details>

<details>
<summary>test_diffusers_inference.py — flash_attention_2 / sdpa comparison test (click to expand)</summary>

```python
"""
Test DeepGen diffusers pipeline with both flash_attention_2 and sdpa.

Usage:
    python test_diffusers_inference.py flash_attention_2
    python test_diffusers_inference.py sdpa
"""
import sys
import torch
from diffusers import DiffusionPipeline
from PIL import Image
import time, os

output_dir = "./test_output"
os.makedirs(output_dir, exist_ok=True)

attn_impl = sys.argv[1] if len(sys.argv) > 1 else "flash_attention_2"
suffix = "flash" if "flash" in attn_impl else "sdpa"

print(f"Testing with attn_implementation={attn_impl}")

pipe = DiffusionPipeline.from_pretrained(
    "deepgenteam/DeepGen-1.0-diffusers",
    torch_dtype=torch.bfloat16,
    trust_remote_code=True,
)
pipe.enable_model_cpu_offload()
pipe._load_extras(attn_implementation=attn_impl)

# Case C: Text-to-Image
t1 = time.time()
result = pipe(
    prompt="a racoon holding a shiny red apple over its head",
    height=512, width=512,
    num_inference_steps=50,
    guidance_scale=4.0,
    seed=42,
)
result.images[0].save(os.path.join(output_dir, f"case_c_{suffix}.png"))
print(f"Case C done in {time.time() - t1:.1f}s")

# Case A: Image Edit (guitar -> beach)
t1 = time.time()
guitar_img = Image.open("downloads/sample/0.png").convert("RGB")
result = pipe(
    prompt="Take a photo of this guitar placed on a sandy beach with the sunset in the background.",
    image=guitar_img,
    height=512, width=512,
    num_inference_steps=50,
    guidance_scale=4.0,
    seed=42,
)
result.images[0].save(os.path.join(output_dir, f"case_a_{suffix}.png"))
print(f"Case A done in {time.time() - t1:.1f}s")

# Case B: Image Edit (car + dog)
t1 = time.time()
car_img = Image.open("downloads/sample/1211.png").convert("RGB")
result = pipe(
    prompt="Add a small brown dog sitting inside the open trunk of the antique car.",
    image=car_img,
    height=512, width=512,
    num_inference_steps=50,
    guidance_scale=4.0,
    seed=42,
)
result.images[0].save(os.path.join(output_dir, f"case_b_{suffix}.png"))
print(f"Case B done in {time.time() - t1:.1f}s")

print(f"All 3 cases ({suffix}) completed!")
```

</details>

## Test Logs

<details>
<summary>Conversion script output</summary>

```
Building model from config...
Loading checkpoint: /data/huggingface/DeepGen-1.0/model.pt
Missing keys (expected - vae/lmm): 625
Saving transformer...
Saving VAE...
Saving scheduler...
Saving connector...
Saving prompt template...
Saving tokenizer...
Conversion complete! Saved to: /tmp/DeepGen-1.0-diffusers
  transformer/
    config.json (0.6 KB)
    diffusion_pytorch_model.safetensors (4710.6 MB)
  vae/
    config.json (0.8 KB)
    diffusion_pytorch_model.safetensors (159.9 MB)
  connector/
    config.json (0.5 KB)
    model.safetensors (1649.7 MB)
  scheduler/
    scheduler_config.json (0.3 KB)
  tokenizer/
    ...
```

</details>

<details>
<summary>Inference test output — flash_attention_2</summary>

```
Loading pipeline components... 3/3
Loading VLM from /data/huggingface/Qwen2.5-VL-3B-Instruct...
Loading tokenizer...
Loading connector...
All components loaded.

=== Case C: Text-to-Image (flash) ===
Case C done in 46.2s

=== Case A: Image Edit (flash) ===
Case A done in 58.0s

=== Case B: Image Edit (flash) ===
Case B done in 56.9s

All 3 cases (flash) completed!
  case_c_flash.png (414.6 KB)
  case_a_flash.png (381.9 KB)
  case_b_flash.png (443.2 KB)
```

</details>

<details>
<summary>Inference test output — sdpa</summary>

```
Loading pipeline components... 3/3
Loading VLM from /data/huggingface/Qwen2.5-VL-3B-Instruct...
Loading tokenizer...
Loading connector...
All components loaded.

=== Case C: Text-to-Image (sdpa) ===
Case C done in 46.1s

=== Case A: Image Edit (sdpa) ===
Case A done in 56.9s

=== Case B: Image Edit (sdpa) ===
Case B done in 56.7s

All 3 cases (sdpa) completed!
  case_c_sdpa.png (415.6 KB)
  case_a_sdpa.png (381.3 KB)
  case_b_sdpa.png (443.5 KB)
```

</details>

## Test Environment

| Item | Configuration |
|---|---|
| **GPU** | NVIDIA L20 (14 GB VRAM) |
| **Driver** | 535.161.07 |
| **OS** | Linux 5.4.119 (glibc 2.28) |
| **Python** | 3.12.4 |
| **PyTorch** | 2.8.0+cu128 |
| **CUDA** | 12.8 |
| **cuDNN** | 9.10.02 |
| **diffusers** | 0.35.2 |
| **transformers** | 4.56.1 |
| **flash-attn** | 2.8.3 |

All tests run with `enable_model_cpu_offload()` due to 14 GB VRAM constraint.
